### PR TITLE
typo: `nixpgs` -> `nixpkgs`

### DIFF
--- a/Nix_Flakes_Explained_4.html
+++ b/Nix_Flakes_Explained_4.html
@@ -339,7 +339,7 @@ will update the whole lock file.</p>
 attribute's value</p>
 <p>Example:</p>
 <pre><code class="language-nix">nix repl
-nix-repl&gt; :l &lt;nixpgs&gt;
+nix-repl&gt; :l &lt;nixpkgs&gt;
 nix-repl&gt; lib.genAttrs [ "boom" "bash" ] (name: "sonic" + namd)
 </code></pre>
 <p><strong>Output</strong>:</p>


### PR DESCRIPTION
Hello,

Thanks for this documentation, here's a PR fixing a very minor things I saw while browsing.